### PR TITLE
Update README: add Contributors section with Caleb

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ As per the current implementation, calculating the full transitive closure of a 
 This means that if you are analyzing a particularly large .jar, or the target method has an extreme number of indirect usages, `rdeps` may take minutes to complete.
 
 In such cases, consider using the `--filter` flag which is used to limit the search space to classes which match the package prefix provided.
+
+## Contributors
+- Caleb
+- Kiril


### PR DESCRIPTION
Add a Contributors section to the README and list Caleb. This documents project contributors in the repository README so readers can see who has contributed. The change appends a new section header and an entry for Caleb at the end of the file.